### PR TITLE
UP-2 | SavedStateHandle support

### DIFF
--- a/sample/src/main/java/com/wesleydonk/update/MainActivity.kt
+++ b/sample/src/main/java/com/wesleydonk/update/MainActivity.kt
@@ -32,7 +32,7 @@ class MainActivity : AppCompatActivity() {
 
         lifecycleScope.launch {
             val version = update.checkLatestVersion()
-            version?.showUpdateDialogFragment(this@MainActivity)
+            version?.showUpdateDialogFragment(supportFragmentManager)
         }
     }
 }

--- a/update-core/build.gradle
+++ b/update-core/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
+    id 'kotlin-parcelize'
     id 'maven-publish'
 }
 

--- a/update-core/src/main/java/com/wesleydonk/update/Version.kt
+++ b/update-core/src/main/java/com/wesleydonk/update/Version.kt
@@ -1,7 +1,11 @@
 package com.wesleydonk.update
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 data class Version(
     val version: String,
     val downloadUrl: String,
     val downloadId: Long?,
-)
+) : Parcelable

--- a/update-ui-no-op/src/main/java/com/wesleydonk/update/ui/internal/extensions/ContextExtensions.kt
+++ b/update-ui-no-op/src/main/java/com/wesleydonk/update/ui/internal/extensions/ContextExtensions.kt
@@ -1,6 +1,9 @@
 package com.wesleydonk.update.ui.internal.extensions
 
 import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentManager
 import com.wesleydonk.update.Version
 
-fun Version.showTryFragment(activity: FragmentActivity) = Unit
+fun Version.showUpdateFragment(fragmentManager: FragmentManager) = Unit
+
+fun Version.showUpdateDialogFragment(fragmentManager: FragmentManager) = Unit

--- a/update-ui/src/main/AndroidManifest.xml
+++ b/update-ui/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
                 android:resource="@xml/share_provider" />
         </provider>
         <receiver
-            android:name=".internal.receivers.ApkInstallReceiver"
+            android:name=".internal.receivers.InstallationReceiver"
             android:exported="false" />
     </application>
 </manifest>

--- a/update-ui/src/main/java/com/wesleydonk/update/ui/UpdateArguments.kt
+++ b/update-ui/src/main/java/com/wesleydonk/update/ui/UpdateArguments.kt
@@ -1,0 +1,26 @@
+package com.wesleydonk.update.ui
+
+import android.os.Bundle
+import androidx.core.os.bundleOf
+import androidx.lifecycle.SavedStateHandle
+import com.wesleydonk.update.Version
+
+data class UpdateArguments(
+    val version: Version
+) {
+    fun toBundle(): Bundle {
+        return bundleOf(
+            EXTRAS_VERSION to version
+        )
+    }
+
+    companion object {
+        private const val EXTRAS_VERSION = "EXTRAS_VERSION"
+
+        fun fromHandle(savedStateHandle: SavedStateHandle): UpdateArguments {
+            return UpdateArguments(
+                requireNotNull(savedStateHandle.get<Version>(EXTRAS_VERSION))
+            )
+        }
+    }
+}

--- a/update-ui/src/main/java/com/wesleydonk/update/ui/UpdateDialogFragment.kt
+++ b/update-ui/src/main/java/com/wesleydonk/update/ui/UpdateDialogFragment.kt
@@ -8,6 +8,7 @@ import androidx.core.view.isInvisible
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
+import com.wesleydonk.update.Version
 import com.wesleydonk.update.ui.databinding.DialogFragmentUpdateBinding
 import com.wesleydonk.update.ui.internal.DownloadStatus
 import com.wesleydonk.update.ui.internal.extensions.observeEvent
@@ -19,7 +20,7 @@ class UpdateDialogFragment : DialogFragment(R.layout.dialog_fragment_update) {
 
     private val viewModel by viewModels<UpdateViewModel> {
         val context = requireContext()
-        UpdateViewModel.Factory(context)
+        UpdateViewModel.Factory(context, this)
     }
 
     private var binding: DialogFragmentUpdateBinding? = null
@@ -29,7 +30,7 @@ class UpdateDialogFragment : DialogFragment(R.layout.dialog_fragment_update) {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         isCancelable = false
-        setStyle(STYLE_NO_TITLE, 0);
+        setStyle(STYLE_NO_TITLE, 0)
     }
 
     override fun onStart() {
@@ -58,11 +59,11 @@ class UpdateDialogFragment : DialogFragment(R.layout.dialog_fragment_update) {
             renderStatus(status)
         }
 
-        viewModel.installApk.observeEvent(viewLifecycleOwner) { installApk ->
+        viewModel.installableFile.observeEvent(viewLifecycleOwner) { file ->
             lifecycleScope.launch {
                 apkManager.install(
-                    installApk.filePath,
-                    installApk.fileMimeType
+                    file.filePath,
+                    file.fileMimeType
                 )
             }
         }
@@ -87,8 +88,10 @@ class UpdateDialogFragment : DialogFragment(R.layout.dialog_fragment_update) {
 
         const val TAG = "UpdateDialogFragment"
 
-        fun newInstance(): UpdateDialogFragment {
-            return UpdateDialogFragment()
+        fun newInstance(version: Version): UpdateDialogFragment {
+            return UpdateDialogFragment().apply {
+                arguments = UpdateArguments(version).toBundle()
+            }
         }
     }
 }

--- a/update-ui/src/main/java/com/wesleydonk/update/ui/UpdateFragment.kt
+++ b/update-ui/src/main/java/com/wesleydonk/update/ui/UpdateFragment.kt
@@ -9,6 +9,7 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
+import com.wesleydonk.update.Version
 import com.wesleydonk.update.ui.databinding.FragmentUpdateBinding
 import com.wesleydonk.update.ui.internal.DownloadStatus
 import com.wesleydonk.update.ui.internal.extensions.observeEvent
@@ -20,7 +21,7 @@ class UpdateFragment internal constructor() : Fragment(R.layout.fragment_update)
 
     private val viewModel by viewModels<UpdateViewModel> {
         val context = requireContext()
-        UpdateViewModel.Factory(context)
+        UpdateViewModel.Factory(context, this)
     }
 
     private val apkManager: ApkManager by lazy { ApkManagerFactory(requireContext()) }
@@ -56,7 +57,7 @@ class UpdateFragment internal constructor() : Fragment(R.layout.fragment_update)
             renderStatus(status)
         }
 
-        viewModel.installApk.observeEvent(viewLifecycleOwner) { installApk ->
+        viewModel.installableFile.observeEvent(viewLifecycleOwner) { installApk ->
             lifecycleScope.launch {
                 apkManager.install(
                     installApk.filePath,
@@ -85,8 +86,10 @@ class UpdateFragment internal constructor() : Fragment(R.layout.fragment_update)
 
         const val TAG = "UpdateFragment"
 
-        fun newInstance(): UpdateFragment {
-            return UpdateFragment()
+        fun newInstance(version: Version): UpdateFragment {
+            return UpdateFragment().apply {
+                arguments = UpdateArguments(version).toBundle()
+            }
         }
     }
 }

--- a/update-ui/src/main/java/com/wesleydonk/update/ui/internal/InstallableFile.kt
+++ b/update-ui/src/main/java/com/wesleydonk/update/ui/internal/InstallableFile.kt
@@ -1,6 +1,6 @@
 package com.wesleydonk.update.ui.internal
 
-internal class InstallApk(
+internal class InstallableFile(
     val filePath: String,
     val fileMimeType: String
 )

--- a/update-ui/src/main/java/com/wesleydonk/update/ui/internal/extensions/ContextExtensions.kt
+++ b/update-ui/src/main/java/com/wesleydonk/update/ui/internal/extensions/ContextExtensions.kt
@@ -1,18 +1,18 @@
 package com.wesleydonk.update.ui.internal.extensions
 
-import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentManager
 import com.wesleydonk.update.Version
 import com.wesleydonk.update.ui.UpdateDialogFragment
 import com.wesleydonk.update.ui.UpdateFragment
 
-fun Version.showUpdateFragment(activity: FragmentActivity) {
-    activity.supportFragmentManager.beginTransaction()
+fun Version.showUpdateFragment(fragmentManager: FragmentManager) {
+    fragmentManager.beginTransaction()
         .add(android.R.id.content, UpdateFragment.newInstance(), UpdateFragment.TAG)
         .addToBackStack(null)
         .commitAllowingStateLoss()
 }
 
-fun Version.showUpdateDialogFragment(activity: FragmentActivity) {
+fun Version.showUpdateDialogFragment(fragmentManager: FragmentManager) {
     UpdateDialogFragment.newInstance()
-        .show(activity.supportFragmentManager, UpdateDialogFragment.TAG)
+        .show(fragmentManager, UpdateDialogFragment.TAG)
 }

--- a/update-ui/src/main/java/com/wesleydonk/update/ui/internal/managers/apk/ApkManagerImpl.kt
+++ b/update-ui/src/main/java/com/wesleydonk/update/ui/internal/managers/apk/ApkManagerImpl.kt
@@ -6,7 +6,7 @@ import android.content.Intent
 import android.content.pm.PackageInstaller
 import androidx.core.content.FileProvider
 import androidx.documentfile.provider.DocumentFile
-import com.wesleydonk.update.ui.internal.receivers.ApkInstallReceiver
+import com.wesleydonk.update.ui.internal.receivers.InstallationReceiver
 import kotlinx.coroutines.Dispatchers
 import java.io.File
 
@@ -36,7 +36,7 @@ internal class ApkManagerImpl(
                     session.fsync(sessionStream)
                 }
 
-                val intent = Intent(context, ApkInstallReceiver::class.java)
+                val intent = Intent(context, InstallationReceiver::class.java)
                 val pendingIntent = PendingIntent.getBroadcast(
                     context,
                     PI_INSTALL,

--- a/update-ui/src/main/java/com/wesleydonk/update/ui/internal/receivers/InstallationReceiver.kt
+++ b/update-ui/src/main/java/com/wesleydonk/update/ui/internal/receivers/InstallationReceiver.kt
@@ -8,7 +8,7 @@ import android.media.AudioManager
 import android.media.ToneGenerator
 import android.util.Log
 
-internal class ApkInstallReceiver : BroadcastReceiver() {
+internal class InstallationReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         val status = intent.getIntExtra(PackageInstaller.EXTRA_STATUS, -1)


### PR DESCRIPTION
- Added `SavedStateHandle` support
- Made `Version` implement `Parcelable`
- Updated no-op variants
- Renamed `ApkInstallReceiver` to `InstallationReceiver`