### PR TITLE
UP-11 | Jitpack using java 11

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
- Jitpack does not run by default on java 11, added a config to make sure jitpack will run on java 11