### PR TITLE
UP-17 | Ensure the maven tasks matches the README

### DIFF
--- a/update-core-no-op/build.gradle.kts
+++ b/update-core-no-op/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
 afterEvaluate {
     publishing {
         publications {
-            create<MavenPublication>("maven") {
+            create<MavenPublication>("release") {
                 from(components["release"])
 
                 groupId = "com.wesleydonk.update"

--- a/update-core/build.gradle.kts
+++ b/update-core/build.gradle.kts
@@ -64,7 +64,7 @@ dependencies {
 afterEvaluate {
     publishing {
         publications {
-            create<MavenPublication>("maven") {
+            create<MavenPublication>("release") {
                 from(components["release"])
 
                 groupId = "com.wesleydonk.update"

--- a/update-fetcher-no-op/build.gradle.kts
+++ b/update-fetcher-no-op/build.gradle.kts
@@ -47,7 +47,7 @@ dependencies {
 afterEvaluate {
     publishing {
         publications {
-            create<MavenPublication>("maven") {
+            create<MavenPublication>("release") {
                 from(components["release"])
 
                 groupId = "com.wesleydonk.update"

--- a/update-fetcher-pov3/build.gradle.kts
+++ b/update-fetcher-pov3/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
 afterEvaluate {
     publishing {
         publications {
-            create<MavenPublication>("maven") {
+            create<MavenPublication>("release") {
                 from(components["release"])
 
                 groupId = "com.wesleydonk.update"

--- a/update-fetcher-pov4/build.gradle.kts
+++ b/update-fetcher-pov4/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
 afterEvaluate {
     publishing {
         publications {
-            create<MavenPublication>("maven") {
+            create<MavenPublication>("release") {
                 from(components["release"])
 
                 groupId = "com.wesleydonk.update"

--- a/update-ui-automation-no-op/build.gradle.kts
+++ b/update-ui-automation-no-op/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
 afterEvaluate {
     publishing {
         publications {
-            create<MavenPublication>("maven") {
+            create<MavenPublication>("release") {
                 from(components["release"])
 
                 groupId = "com.wesleydonk.update"

--- a/update-ui-automation/build.gradle.kts
+++ b/update-ui-automation/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
 afterEvaluate {
     publishing {
         publications {
-            create<MavenPublication>("maven") {
+            create<MavenPublication>("release") {
                 from(components["release"])
 
                 groupId = "com.wesleydonk.update"

--- a/update-ui-no-op/build.gradle.kts
+++ b/update-ui-no-op/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
 afterEvaluate {
     publishing {
         publications {
-            create<MavenPublication>("maven") {
+            create<MavenPublication>("release") {
                 from(components["release"])
 
                 groupId = "com.wesleydonk.update"

--- a/update-ui/build.gradle.kts
+++ b/update-ui/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
 afterEvaluate {
     publishing {
         publications {
-            create<MavenPublication>("maven") {
+            create<MavenPublication>("release") {
                 from(components["release"])
 
                 groupId = "com.wesleydonk.update"


### PR DESCRIPTION
- Publication task now matches the README with 'Release' instead of 'Maven'